### PR TITLE
replace base64sha256 with filebase64sha256.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ resource "aws_lambda_layer_version" "this" {
   filename            = "${path.module}/files/layer.zip"
   compatible_runtimes = [var.lambda_runtime]
 
-  source_code_hash = base64sha256("${path.module}/files/layer.zip")
+  source_code_hash = filebase64sha256("${path.module}/files/layer.zip")
 }
 
 resource "aws_lambda_function" "update_clamav_definitions" {
@@ -169,7 +169,7 @@ resource "aws_lambda_function" "update_clamav_definitions" {
   function_name    = local.clamav_update_name
   role             = aws_iam_role.update.arn
   handler          = var.update_handler
-  source_code_hash = base64sha256("${path.module}/files/code.zip")
+  source_code_hash = filebase64sha256("${path.module}/files/code.zip")
   runtime          = var.lambda_runtime
   timeout          = var.lambda_timeout
   memory_size      = var.update_memory_size
@@ -188,7 +188,7 @@ resource "aws_lambda_function" "scan_file" {
   function_name    = local.clamav_scan_name
   role             = aws_iam_role.scan.arn
   handler          = var.scan_handler
-  source_code_hash = base64sha256("${path.module}/files/code.zip")
+  source_code_hash = filebase64sha256("${path.module}/files/code.zip")
   runtime          = var.lambda_runtime
   timeout          = var.lambda_timeout
   memory_size      = var.scan_memory_size


### PR DESCRIPTION
`filebase64sha256` is recommended for binary files.
using `base64sha256` to calculate `source_code_hash` on an unmodified zip file (`code.zip` / `layer.zip`) results in resources getting marked as changed by terraform plan.
for more info see https://www.terraform.io/language/functions/filebase64sha256